### PR TITLE
patch for htmlwidget support in iframes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: slickR
 Title: Create Interactive Carousels with the JavaScript 'Slick'
     Library
-Version: 0.4.7
-Date: 2019-10-15
+Version: 0.4.8
+Date: 2019-12-13
 Authors@R: 
     person(given = "Jonathan",
            family = "Sidi",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# slickR 0.4.8
+
+* Change the slckR.js script to support htmlwidgets in iframe src
+
 # slickR 0.4.6
 
 * Add new settings functions to control the settings of a slick object

--- a/inst/htmlwidgets/lib/slickR/slickR.js
+++ b/inst/htmlwidgets/lib/slickR/slickR.js
@@ -149,7 +149,7 @@ HTMLWidgets.widget({
               switch (objType) {
                 
                 case 'iframe':
-                  newEl.src = 'data:text/html;charset=utf-8,' + encodeURI(obj[i]);
+                  newEl.srcdoc = obj[i];
                   newEl.style.height=height;
                 break;
                 


### PR DESCRIPTION
js: change iframe in widget to srcdoc instead of src to fix htmlwidget support problem