### PR TITLE
Update charset declaration in slick-theme.css

### DIFF
--- a/inst/htmlwidgets/lib/slick-1.8.1/slick/slick-theme.css
+++ b/inst/htmlwidgets/lib/slick-1.8.1/slick/slick-theme.css
@@ -1,4 +1,4 @@
-@charset 'UTF-8';
+@charset "UTF-8";
 /* Slider */
 .slick-loading .slick-list
 {


### PR DESCRIPTION
Updating the charset declaration according to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@charset), that shows double quotes are needed. This error sometimes caused the wrong encoding of the characters used in the carousel buttons, showing weird characters.